### PR TITLE
Fix hidden 500-item history cap (#13)

### DIFF
--- a/ClipPocket/Utilities/SettingsManager.swift
+++ b/ClipPocket/Utilities/SettingsManager.swift
@@ -69,6 +69,21 @@ class SettingsManager: ObservableObject {
         }
     }
 
+    /// Resolved history cap actually enforced at runtime.
+    /// When the user disables the limit, this is `.max` (no application-level cap);
+    /// memory pressure is managed by the per-item image filter, not a count ceiling.
+    var effectiveHistoryLimit: Int {
+        Self.effectiveHistoryLimit(
+            enableHistoryLimit: enableHistoryLimit,
+            maxHistoryItems: maxHistoryItems
+        )
+    }
+
+    static func effectiveHistoryLimit(enableHistoryLimit: Bool, maxHistoryItems: Int) -> Int {
+        guard enableHistoryLimit else { return .max }
+        return max(1, maxHistoryItems)
+    }
+
     @Published var autoShowOnEdge: Bool {
         didSet {
             defaults.set(autoShowOnEdge, forKey: Keys.autoShowOnEdge)

--- a/ClipPocket/Views/SettingsView.swift
+++ b/ClipPocket/Views/SettingsView.swift
@@ -621,9 +621,7 @@ struct SettingsView: View {
                     let data = try ClipboardBackupManager.shared.exportBackup(
                         history: appDelegate.clipboardItems,
                         pinned: appDelegate.pinnedManager.pinnedItems,
-                        maxHistory: appDelegate.settingsManager.enableHistoryLimit
-                            ? min(appDelegate.settingsManager.maxHistoryItems, 500)
-                            : 500,
+                        maxHistory: appDelegate.settingsManager.effectiveHistoryLimit,
                         maxPinned: 50
                     )
                     try data.write(to: url)
@@ -645,9 +643,7 @@ struct SettingsView: View {
                     let data = try Data(contentsOf: url)
                     let imported = try ClipboardBackupManager.shared.importBackup(
                         from: data,
-                        maxHistory: appDelegate.settingsManager.enableHistoryLimit
-                            ? min(appDelegate.settingsManager.maxHistoryItems, 500)
-                            : 500,
+                        maxHistory: appDelegate.settingsManager.effectiveHistoryLimit,
                         maxPinned: 50
                     )
                     appDelegate.clipboardItems = imported.history

--- a/ClipPocket/app/ClipPocketApp.swift
+++ b/ClipPocket/app/ClipPocketApp.swift
@@ -499,7 +499,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             let encoder = JSONEncoder()
             encoder.outputFormatting = .prettyPrinted
 
-            let itemsToSave = clipboardItems.prefix(500).filter { item in
+            let itemsToSave = clipboardItems.prefix(settingsManager.effectiveHistoryLimit).filter { item in
                 if case .image = item.type,
                    let imageData = item.content as? Data,
                    imageData.count > 1_048_576 { return false }
@@ -647,11 +647,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
             print("🧹 Filtered \(loadedItems.count - filteredItems.count) large images")
 
-            // Apply hard limit - max 500 items
-            let maxItems = settingsManager.enableHistoryLimit
-                ? min(settingsManager.maxHistoryItems, 500)
-                : 500
-
+            // Honor the user-selected limit; when the toggle is off, keep everything.
+            let maxItems = settingsManager.effectiveHistoryLimit
             clipboardItems = Array(filteredItems.prefix(maxItems))
 
             let memoryEstimate = estimateMemoryUsage(clipboardItems)
@@ -690,7 +687,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
                 encoder.outputFormatting = .prettyPrinted
 
                 // Filter out items with large data (> 1MB per item) before saving
-                let itemsToSave = self.clipboardItems.prefix(500).filter { item in
+                let itemsToSave = self.clipboardItems.prefix(self.settingsManager.effectiveHistoryLimit).filter { item in
                     // Skip very large images
                     if case .image = item.type,
                        let imageData = item.content as? Data,
@@ -732,7 +729,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             encoder.outputFormatting = .prettyPrinted
 
             // Filter out items with large data (> 1MB per item) before saving
-            let itemsToSave = clipboardItems.prefix(500).filter { item in
+            let itemsToSave = clipboardItems.prefix(settingsManager.effectiveHistoryLimit).filter { item in
                 // Skip very large images
                 if case .image = item.type,
                    let imageData = item.content as? Data,
@@ -1031,15 +1028,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             if !self.clipboardItems.contains(where: { $0.isEqual(to: item) }) {
                 self.clipboardItems.insert(item, at: 0)
 
-                // Enforce hard limit during runtime to prevent unbounded memory growth
-                let hardLimit = self.settingsManager.enableHistoryLimit
-                    ? min(self.settingsManager.maxHistoryItems, 500)
-                    : 500  // Default max of 500 items for memory efficiency
-
-                if self.clipboardItems.count > hardLimit {
-                    let removedCount = self.clipboardItems.count - hardLimit
+                // Trim only when the user has an explicit limit; otherwise keep growing.
+                let hardLimit = self.settingsManager.effectiveHistoryLimit
+                if hardLimit != .max, self.clipboardItems.count > hardLimit {
                     self.clipboardItems = Array(self.clipboardItems.prefix(hardLimit))
-                    print("⚠️ Trimmed \(removedCount) old items (limit: \(hardLimit))")
                 }
 
                 print("Added new clipboard item: \(item.displayString)")

--- a/ClipPocketTests/ClipPocketTests.swift
+++ b/ClipPocketTests/ClipPocketTests.swift
@@ -10,8 +10,18 @@ import Testing
 
 struct ClipPocketTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-    }
+    @Test func effectiveHistoryLimitHonorsUserToggle() {
+        // Toggle off means unlimited, regardless of the stored slider value.
+        #expect(SettingsManager.effectiveHistoryLimit(enableHistoryLimit: false, maxHistoryItems: 100) == .max)
+        #expect(SettingsManager.effectiveHistoryLimit(enableHistoryLimit: false, maxHistoryItems: 1) == .max)
 
+        // Toggle on honors the user-selected value, including values above the old 500 cap.
+        #expect(SettingsManager.effectiveHistoryLimit(enableHistoryLimit: true, maxHistoryItems: 100) == 100)
+        #expect(SettingsManager.effectiveHistoryLimit(enableHistoryLimit: true, maxHistoryItems: 800) == 800)
+        #expect(SettingsManager.effectiveHistoryLimit(enableHistoryLimit: true, maxHistoryItems: 1000) == 1000)
+
+        // Guard against nonsense values without silently dropping items.
+        #expect(SettingsManager.effectiveHistoryLimit(enableHistoryLimit: true, maxHistoryItems: 0) == 1)
+        #expect(SettingsManager.effectiveHistoryLimit(enableHistoryLimit: true, maxHistoryItems: -5) == 1)
+    }
 }


### PR DESCRIPTION
## Summary
- The `Limit History Size` toggle silently used `500` when off, and the slider was clamped by `min(maxHistoryItems, 500)` when on. So "unlimited" was a lie and slider values 501-1000 were quietly ignored, causing history to plateau at exactly 500. This is the shape reported in #13.
- Centralized the resolved cap in a single `SettingsManager.effectiveHistoryLimit` used by save, load, runtime insert, and backup export. Toggle off honors "unlimited"; toggle on uses the exact slider value.
- Added a unit test covering the new resolver (toggle off, above/at/below the old 500, and out-of-range guards).

## Files touched
- `ClipPocket/Utilities/SettingsManager.swift` - new `effectiveHistoryLimit` + testable static helper
- `ClipPocket/app/ClipPocketApp.swift` - five sites (load, three save paths, runtime insert) now use `effectiveHistoryLimit`
- `ClipPocket/Views/SettingsView.swift` - backup export uses `effectiveHistoryLimit`
- `ClipPocketTests/ClipPocketTests.swift` - covers the resolver

## Test plan
- [x] `xcodebuild ... test` passes locally on macOS arm64 (unit + UI launch tests all green)
- [ ] Manual: toggle off, copy > 500 items, confirm history keeps growing past 500
- [ ] Manual: toggle on with slider at 800, copy > 800 items, confirm history stops at 800 (was capped at 500 before)
- [ ] Manual: toggle on with slider at 200, confirm nothing regressed for the majority case

## Follow-up (not in this PR)
- The bounded-by-count design has no memory safety valve once the toggle is off. A separate change should trim by *estimated memory usage* instead, so unlimited stays honest but a runaway image-heavy history cannot OOM. The `estimateMemoryUsage` helper is already in place.

Closes #13