### PR TITLE
CI: rebuild DMG on main pushes and manual dispatch

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -48,7 +54,17 @@ jobs:
             "ClipPocket.dmg" \
             "build/Build/Products/Release/ClipPocket.app"
 
+      - name: Upload DMG artifact
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ClipPocket-${{ github.sha }}
+          path: ClipPocket.dmg
+          if-no-files-found: error
+          retention-days: 30
+
       - name: Create GitHub Release
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: softprops/action-gh-release@v2
         with:
           files: ClipPocket.dmg


### PR DESCRIPTION
## Summary
The current \`build-release.yml\` only fires on \`v*\` tag pushes, so there's no way to get a fresh DMG built from HEAD without cutting a tag. This adds:

- \`workflow_dispatch\` trigger, so the workflow can be run on demand from the Actions tab.
- \`push: branches: [main]\` trigger, so every merge to main produces a fresh DMG.
- Tag builds still cut a GitHub Release (unchanged path). Non-tag builds upload the DMG as a 30-day workflow artifact instead of publishing, so main-branch builds don't spam Releases.
- Explicit \`permissions: contents: write\` at the workflow level, which some org policies require for \`softprops/action-gh-release\`.

## Test plan
- [ ] After merge, confirm the workflow appears with a "Run workflow" button on the Actions tab (evidence \`workflow_dispatch\` is wired).
- [ ] Push a trivial commit to main and confirm the workflow runs and produces a \`ClipPocket-<sha>\` artifact, not a Release.
- [ ] Cut a throwaway pre-release tag (e.g. \`v0.0.0-test\`) on a scratch branch to confirm the Release path still fires; delete after.

## Not in this PR (flag for later)
- The release step's \`body:\` is a hardcoded v2.6.0 changelog. Any future tag build will attach v2.6.0's notes to a different version's release. Worth swapping for \`generate_release_notes: true\` or a per-tag \`CHANGELOG.md\` extraction. Separate issue.